### PR TITLE
add separate new-relic configuration

### DIFF
--- a/provisioning/deploy-app-server.yml
+++ b/provisioning/deploy-app-server.yml
@@ -23,11 +23,6 @@
     - name: copy over generated css
       copy: src=../static/{{theme_to_deploy}}/css/style.css dest={{project_root}}/static/{{theme_to_deploy}}/css/style.css owner=web group=web mode=755
 
-    - name: add new-relic-config
-      template: src=templates/newrelic.js.j2 dest={{project_root}}/newrelic.js backup=yes
-      sudo: yes
-      sudo_user: web
-
     - name: update config
       template: src=templates/config.js.j2 dest={{project_root}}/config-production.js backup=yes
       sudo: yes

--- a/provisioning/new-relic.yml
+++ b/provisioning/new-relic.yml
@@ -26,10 +26,7 @@
       apt_key: https://download.newrelic.com/548C16BF.gpg
 
     - name: add new-relic package to apt
-      shell: echo deb http://apt.newrelic.com/debian/ newrelic non-free >> /etc/apt/sources.list.d/newrelic.list
-
-    - name: add chris lea's ppa
-      apt_repository: repo='ppa:chris-lea/node.js' state=present update_cache=yes
+      apt_repository: repo='deb http://apt.newrelic.com/debian/ newrelic non-free' update_cache=yes
 
     - name: add new relic daemon
       apt: pkg=newrelic-sysmond state=latest

--- a/provisioning/new-relic.yml
+++ b/provisioning/new-relic.yml
@@ -1,0 +1,43 @@
+# apm - application based monitoring
+
+- hosts: app
+  vars_files:
+    - vars.yml
+    - private/private-vars.yml
+
+  sudo: yes
+  user: root
+
+    - name: add new-relic-config
+      template: src=templates/newrelic.js.j2 dest={{project_root}}/newrelic.js backup=yes
+      sudo: yes
+      sudo_user: web
+
+# server - server based monitoring
+
+- hosts: app loadbalancer
+  vars_files:
+    - private/private-vars.yml
+
+  sudo: yes
+  user: root
+
+    - name: add new-relic key
+      apt_key: https://download.newrelic.com/548C16BF.gpg
+
+    - name: add new-relic package to apt
+      shell: echo deb http://apt.newrelic.com/debian/ newrelic non-free >> /etc/apt/sources.list.d/newrelic.list
+
+    - name: add chris lea's ppa
+      apt_repository: repo='ppa:chris-lea/node.js' state=present update_cache=yes
+
+    - name: add new relic daemon
+      apt: pkg=newrelic-sysmond state=latest
+      notify: start daemon
+
+    - name: set license key
+      command: nrsysmond-config --set license_key={{new_relic_key}}
+
+  handlers:
+    - name: start daemon
+      shell: /etc/init.d/newrelic-sysmond start


### PR DESCRIPTION
- allows for separate configuration of new relic, closes #63
- add new relic daemon to loadbalancer and app servers to monitor
  the overall machine metrics (cpu, memory etc)
