### PR TITLE
fix ga code violating csp

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,4 @@
 **/node_modules
 **/bower_components
 **/external/
+/static/basic-theme/ga.js

--- a/server.js
+++ b/server.js
@@ -70,7 +70,7 @@ function bootServer (cb) {
       register: Blankie,
       options: {
         defaultSrc: 'none',
-        scriptSrc: 'self',
+        scriptSrc: ['self', 'www.google-analytics.com'],
         styleSrc: ['unsafe-inline', 'self', 'fonts.googleapis.com'],
         imgSrc: '*',
         connectSrc: 'self',

--- a/static/basic-theme/ga.js
+++ b/static/basic-theme/ga.js
@@ -1,0 +1,8 @@
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', '{{googleAnalyticsUaCode}}', 'auto');
+ga('set', 'anonymizeIp', true);
+ga('send', 'pageview');

--- a/static/basic-theme/ga.js
+++ b/static/basic-theme/ga.js
@@ -3,6 +3,22 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-ga('create', '{{googleAnalyticsUaCode}}', 'auto');
-ga('set', 'anonymizeIp', true);
-ga('send', 'pageview');
+(function() {
+
+  /**
+   * read data-ua-code attribute configured on surrounding script tag
+   * would probably fail if script is loaded async
+   *
+   * @returns {string|*}
+   */
+  function readUaCode() {
+    var scripts = document.getElementsByTagName('script');
+    var currentScript = scripts[scripts.length -1];
+
+    return currentScript.getAttribute('data-ua-code');
+  }
+
+  ga('create', readUaCode(), 'auto');
+  ga('set', 'anonymizeIp', true);
+  ga('send', 'pageview');
+})();

--- a/templates/basic-theme/layout.hbs
+++ b/templates/basic-theme/layout.hbs
@@ -111,6 +111,6 @@
       </footer>
     </div>
 
-    <script src="/static/basic-theme/ga.js"></script>
+    <script src="/static/basic-theme/ga.js" data-ua-code="{{googleAnalyticsUaCode}}"></script>
   </body>
 </html>

--- a/templates/basic-theme/layout.hbs
+++ b/templates/basic-theme/layout.hbs
@@ -111,15 +111,6 @@
       </footer>
     </div>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', '{{googleAnalyticsUaCode}}', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
-    </script>
+    <script src="/static/basic-theme/ga.js"></script>
   </body>
 </html>

--- a/test/unit/csp.js
+++ b/test/unit/csp.js
@@ -25,7 +25,7 @@ describe('Server', function () {
   it('sends csp headers', function (done) {
     request('http://' + config.host + ':' + config.port, function (err, res, body) {
       expect(res.headers['content-security-policy'])
-        .to.equal("default-src 'none';script-src 'self';style-src 'unsafe-inline' 'self' fonts.googleapis.com;img-src *;connect-src 'self';font-src 'self' data: fonts.gstatic.com");
+        .to.equal("default-src 'none';script-src 'self' www.google-analytics.com;style-src 'unsafe-inline' 'self' fonts.googleapis.com;img-src *;connect-src 'self';font-src 'self' data: fonts.gstatic.com");
       done();
     });
   });


### PR DESCRIPTION
I'm wondering how ga is able to collect any data at all (it does!), because it's not loaded due to inline scripts violating current csp: 

```
 Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution.
```

@robertkowalski Do you have an idea how to best fix that problem.

We could either just allow unsafe-inline script, otherwise we need to provide the uaCode to the script. I currently do that by reading attribute from the including script tag. (Which could break when script is loaded async) But I'm afraid that's not best practise? Please read about some alternatives I came up with in the commit message here: https://github.com/jsunconf/contriboot/commit/cb3af8cc73e450fb8bc661eaf73b5b265e8e40b0

Any thoughts? :)
